### PR TITLE
`#useLatestMetacello : true`

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -3,8 +3,9 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'Voyage',
       #directory : 'mc',
-	  #load : [ 'mongo tests' ],	  
-      #platforms : [ #pharo ]
+      #load : [ 'mongo tests' ],	  
+      #platforms : [ #pharo ],
+      #useLatestMetacello : true
     }
   ]
 }


### PR DESCRIPTION
This is needed to support metadataless Metacello in Pharo 3 and 4.