### PR TITLE
Fix concurrent pool flushing and population

### DIFF
--- a/mc/Voyage-Mongo-Core.package/VOMongoRepositoryResolver.class/instance/resetPool.st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoRepositoryResolver.class/instance/resetPool.st
@@ -1,7 +1,13 @@
 accessing
 resetPool
 	"Assume primaryMember is up-to-date"
-	pool ifNotNil: [ pool flush ].
+	pool ifNotNil: [
+		"VOMongoSessionPool>>#populate might run while we try to flush the
+		pool. Make sure that 'new' sessions added to the old pool will be
+		immediately disconnected instead of being leaked."
+		pool
+			size: 0;
+			flush ].
 	pool := VOMongoSessionPool
 		host: self mongoUrlResolver primaryMongoUrl host 
 		port: self mongoUrlResolver primaryMongoUrl port


### PR DESCRIPTION
If VOMongoSessionPool>>#populate is executing/scheduled while we call "pool flush" we would disconnect all open connections, then fill up the pool and finally discard the session pool. This leads to leaked connections that will eventually cause the image to run out of external semaphores.