### PR TITLE
Make >>#asMongoUrl add a default port

### DIFF
--- a/mc/Voyage-Mongo-Core.package/String.extension/instance/asMongoUrl.st
+++ b/mc/Voyage-Mongo-Core.package/String.extension/instance/asMongoUrl.st
@@ -1,3 +1,6 @@
 *Voyage-Mongo-Core-Extensions
 asMongoUrl
-	^ ZnUrl fromString: self defaultScheme: #mongodb
+	| url |
+	url := ZnUrl fromString: self defaultScheme: #mongodb.
+	url hasPort ifFalse: [ url port: 27017 ].
+	^ url

--- a/mc/Voyage-Mongo-Tests.package/VOMongoUrlTest.class/instance/testDefaultPortUrl.st
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoUrlTest.class/instance/testDefaultPortUrl.st
@@ -1,0 +1,7 @@
+tests
+testDefaultPortUrl
+	| url |
+	url := 'db.myserver' asMongoUrl.
+	self assert: url scheme equals: 'mongodb'.
+	self assert: url host equals: 'db.myserver'.
+	self assert: url port equals: 27017.

--- a/mc/Voyage-Mongo-Tests.package/VOMongoUrlTest.class/instance/testFullUrl.st
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoUrlTest.class/instance/testFullUrl.st
@@ -1,0 +1,7 @@
+tests
+testFullUrl
+	| url |
+	url := 'db.myserver:8888' asMongoUrl.
+	self assert: url scheme equals: 'mongodb'.
+	self assert: url host equals: 'db.myserver'.
+	self assert: url port equals: 8888.

--- a/mc/Voyage-Mongo-Tests.package/VOMongoUrlTest.class/properties.json
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoUrlTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "Voyage-Mongo-Tests-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "VOMongoUrlTest",
+	"type" : "normal"
+}


### PR DESCRIPTION
Add a simple testcase verifying that the port is parsed and that a port is added.

Make 'localhost' asMongoUrl work when added to the list of servers for the replication set.