### PR TITLE
Allow to specify a socket connection timeout for all mongo connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,6 @@ matrix:
 #    - smalltalk: Pharo-6.1
 #      before_script: wget https://github.com/pharo-nosql/PunQLite/releases/download/stable/unqlite.so
 #      smalltalk_config: .smalltalk-unqlite.ston
-    - smalltalk: Pharo-5.0
-      smalltalk_config: .smalltalk-legacy.ston
-      env: MONGODB=3.4
-#    - smalltalk: Pharo-5.0
-#      before_script: wget https://github.com/pharo-nosql/PunQLite/releases/download/stable/unqlite.so
-#      smalltalk_config: .smalltalk-unqlite.ston
-#      env: MONGODB=3.4
 
 # bob-bench xUnit file analysis (?where is my xml?)
 after_script:

--- a/mc/BaselineOfVoyage.package/BaselineOfVoyage.class/instance/mongoTalk..st
+++ b/mc/BaselineOfVoyage.package/BaselineOfVoyage.class/instance/mongoTalk..st
@@ -2,5 +2,5 @@ external projects
 mongoTalk: spec
 	spec 
 		baseline: 'MongoTalk' 
-			with: [ spec repository: 'github://pharo-nosql/mongotalk:1.16/mc' ];
+			with: [ spec repository: 'github://pharo-nosql/mongotalk:1.18/mc' ];
 		import: 'MongoTalk'

--- a/mc/Voyage-Model-Core.package/VOSessionPool.class/instance/connectionTimeout..st
+++ b/mc/Voyage-Model-Core.package/VOSessionPool.class/instance/connectionTimeout..st
@@ -1,0 +1,3 @@
+accessing
+connectionTimeout: aTimeout
+	connectionTimeout := aTimeout

--- a/mc/Voyage-Model-Core.package/VOSessionPool.class/instance/ensureConnected..st
+++ b/mc/Voyage-Model-Core.package/VOSessionPool.class/instance/ensureConnected..st
@@ -1,4 +1,4 @@
 private
 ensureConnected: aSession
 	^ aSession isOpen 
-		ifFalse: [ aSession open ]
+		ifFalse: [ aSession openWithTimeout: connectionTimeout ]

--- a/mc/Voyage-Model-Core.package/VOSessionPool.class/instance/initialize.st
+++ b/mc/Voyage-Model-Core.package/VOSessionPool.class/instance/initialize.st
@@ -2,4 +2,5 @@ initialization
 initialize
 	super initialize.
 	sessions := SharedQueue new.
+	connectionTimeout := Socket standardTimeout seconds.
 	self populate

--- a/mc/Voyage-Model-Core.package/VOSessionPool.class/properties.json
+++ b/mc/Voyage-Model-Core.package/VOSessionPool.class/properties.json
@@ -11,7 +11,8 @@
 		"sessions",
 		"size",
 		"mutex",
-		"process"
+		"process",
+		"connectionTimeout"
 	],
 	"name" : "VOSessionPool",
 	"type" : "normal"

--- a/mc/Voyage-Mongo-Core.package/VOMongoReplicationUrlResolver.class/instance/basicLookupReplicaSetStatusIfFound..st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoReplicationUrlResolver.class/instance/basicLookupReplicaSetStatusIfFound..st
@@ -4,7 +4,7 @@ basicLookupReplicaSetStatusIfFound: callbackBlock
 	| mongo |
 	knownMongoUrls do: [ :each | [[ 
 		mongo := Mongo host: each host port: each port.
-		mongo open.
+		mongo openWithTimeout: repository connectionTimeout.
 		^ callbackBlock value: mongo replicaSetStatus ]
 			on: NetworkError "Unavailable member => skip"
 			do: [ :error | 	repository debugLog: each asString , '->' , error asString ]]

--- a/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/class/defaultConnectionTimeout.st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/class/defaultConnectionTimeout.st
@@ -1,0 +1,3 @@
+defaults
+defaultConnectionTimeout
+	^ Socket standardTimeout seconds

--- a/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/instance/connectionTimeout..st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/instance/connectionTimeout..st
@@ -1,0 +1,3 @@
+accessing
+connectionTimeout: aTimeout
+	connectionTimeout := aTimeout

--- a/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/instance/connectionTimeout.st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/instance/connectionTimeout.st
@@ -1,0 +1,3 @@
+accessing
+connectionTimeout
+	^ connectionTimeout ifNil: [ connectionTimeout := self class defaultConnectionTimeout ]

--- a/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/instance/resetPool.st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/instance/resetPool.st
@@ -15,3 +15,4 @@ resetPool
 		username: self username 
 		password: self password.
 	pool size: self poolSize.
+	pool connectionTimeout: self connectionTimeout.

--- a/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/properties.json
+++ b/mc/Voyage-Mongo-Core.package/VOMongoRepository.class/properties.json
@@ -19,7 +19,8 @@
 		"ensuringCurrentReferencesOnQueries",
 		"lazySynchronize",
 		"pool",
-		"mongoUrlResolver"
+		"mongoUrlResolver",
+		"connectionTimeout"
 	],
 	"name" : "VOMongoRepository",
 	"type" : "normal"


### PR DESCRIPTION
The replicaSetLookupTimeout should be more than connectionTimeoutSeconds to allow all servers to be contacted. This needs to be tuned depending on the size of the replication set.