### PR TITLE
Resurrected left overs from old VOCache race condition protection

### DIFF
--- a/mc/Voyage-Model-Core.package/VOCache.class/instance/cacheObject.id.version..st
+++ b/mc/Voyage-Model-Core.package/VOCache.class/instance/cacheObject.id.version..st
@@ -1,5 +1,8 @@
 accessing
-cacheObject: anObject id: anId version: aVersion
+cacheObject: anObject id: anOID version: aVersion
 
-	self at: anId put: anObject.
-	self at: anId putVersion: aVersion 
+	self compactIfNeeded.
+	self mutex critical: [ 
+		objects at: anOID put: anObject.
+		reversedObjects at: anObject put: anOID.
+		versions at: anOID put: aVersion].

--- a/mc/Voyage-Model-Core.package/VOCache.class/instance/objectAndVersionAt..st
+++ b/mc/Voyage-Model-Core.package/VOCache.class/instance/objectAndVersionAt..st
@@ -1,0 +1,7 @@
+accessing
+objectAndVersionAt: anOID
+	self mutex critical: [
+		^Array
+			with: (self at: anOID)
+			with: (self versionAt: anOID)
+	]

--- a/mc/Voyage-Model-Core.package/VOExternalRepository.class/instance/retrieveInstanceOf.serialized.lazy..st
+++ b/mc/Voyage-Model-Core.package/VOExternalRepository.class/instance/retrieveInstanceOf.serialized.lazy..st
@@ -1,11 +1,12 @@
 private retrieving
 retrieveInstanceOf: aClass serialized: serialized lazy: isLazy
-	| id cacheForClass cachedVersion serializedVersion cachedObject result | 
+	| id cacheForClass cachedVersion serializedVersion cachedObject result cachedObjectAndId | 
 
 	id := self idFromSerialized: serialized.
 	cacheForClass := self cacheFor: aClass. 
-	cachedObject := cacheForClass at: id.
-	cachedVersion := cachedObject ifNotNil: [ cacheForClass versionAt: id ].
+	cachedObjectAndId := cacheForClass objectAndVersionAt: id.
+	cachedObject := cachedObjectAndId first.
+	cachedVersion := cachedObjectAndId second.
 	serializedVersion := self versionFromSerialized: serialized.
 	result := cachedObject.
 	


### PR DESCRIPTION
This is an added race condition protection when retrieving or storing cache objects and versions independently