### PR TITLE
Ensuring that all MongoMonitor instances are correctly stopped and removed from the TKTService registry.

### DIFF
--- a/mc/Voyage-Mongo-Core.package/MongoMonitor.extension/instance/ensureStop..st
+++ b/mc/Voyage-Mongo-Core.package/MongoMonitor.extension/instance/ensureStop..st
@@ -1,0 +1,11 @@
+*Voyage-Mongo-Core
+ensureStop: timeout
+	
+	self isRunning 
+		ifTrue: [ ^ self stop waitForCompletion: timeout ].
+	
+	stopCallbacks ifNotNil: [ ^ self stop ].
+
+	"I have been never started... lets ensure I am not in the service manager"	
+	stopRequested := true.
+	TKTConfiguration serviceManager removeService: self

--- a/mc/Voyage-Mongo-Core.package/MongoMonitor.extension/properties.json
+++ b/mc/Voyage-Mongo-Core.package/MongoMonitor.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "MongoMonitor"
+}

--- a/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/newRepository.st
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/newRepository.st
@@ -1,0 +1,6 @@
+tests
+newRepository
+
+	^ VOMongoRepository
+		  host: VOMongoTest mongoHost
+		  database: 'Voyage-Tests'

--- a/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/tearDown.st
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/tearDown.st
@@ -1,0 +1,5 @@
+running
+tearDown
+
+	TKTConfiguration serviceManager purge.
+	super tearDown

--- a/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/testFinalizationShouldRemoveMonitorsFromServiceCollectionWhenTheyAreNotRunning.st
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/testFinalizationShouldRemoveMonitorsFromServiceCollectionWhenTheyAreNotRunning.st
@@ -1,0 +1,22 @@
+tests
+testFinalizationShouldRemoveMonitorsFromServiceCollectionWhenTheyAreNotRunning
+
+	| before repository after monitorNames processesToKill |
+	
+	before := TKTConfiguration serviceManager services select: [ :e | e isKindOf: MongoMonitor ].
+
+	repository := self newRepository.
+
+	"Kill all worker processes from outside, it might happen..."
+	monitorNames := repository sdamClient monitors values collect: [ :e | e name ]. 
+	processesToKill := Process allInstances select: [:e | monitorNames includes: e name].
+	processesToKill do: [:e | e terminate].
+
+	repository := nil.
+	
+	"Force collection and finalization"
+	3 timesRepeat: [ Smalltalk garbageCollect ].
+	
+	after :=  TKTConfiguration serviceManager services select: [ :e | e isKindOf: MongoMonitor ].
+	
+	self assertCollection: after hasSameElements: before

--- a/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/testFinalizationShouldRemoveMonitorsFromServiceCollectionWhenTheyAreRunning.st
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/instance/testFinalizationShouldRemoveMonitorsFromServiceCollectionWhenTheyAreRunning.st
@@ -1,0 +1,16 @@
+tests
+testFinalizationShouldRemoveMonitorsFromServiceCollectionWhenTheyAreRunning
+
+	| before repository after |
+	
+	before := TKTConfiguration serviceManager services select: [ :e | e isKindOf: MongoMonitor ].
+
+	repository := self newRepository.
+	repository := nil.
+	
+	"Force collection and finalization"
+	3 timesRepeat: [ Smalltalk garbageCollect ].
+	
+	after :=  TKTConfiguration serviceManager services select: [ :e | e isKindOf: MongoMonitor ].
+	
+	self assertCollection: after hasSameElements: before

--- a/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/properties.json
+++ b/mc/Voyage-Mongo-Tests.package/VOMongoFinalizationTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "Voyage-Mongo-Tests-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "VOMongoFinalizationTest",
+	"type" : "normal"
+}

--- a/mc/Voyage-Mongo-Tests.package/monticello.meta/categories.st
+++ b/mc/Voyage-Mongo-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,2 @@
-self packageOrganizer ensurePackage: #'Voyage-Mongo-Tests' withTags: #('Core' 'Replication')!
+SystemOrganization addCategory: #'Voyage-Mongo-Tests'!
+SystemOrganization addCategory: #'Voyage-Mongo-Tests-Core'!


### PR DESCRIPTION
Fix #192